### PR TITLE
Update css for announcement bar

### DIFF
--- a/assets/scss/_nav.scss
+++ b/assets/scss/_nav.scss
@@ -2,12 +2,9 @@
 // Main navbar
 //
 .td-navbar-cover {
-
     background: #3e3e3e;
     @include media-breakpoint-up(md) {
         background: #3e3e3e;
-
-
     }
     &.navbar-bg-onscroll .nav-link {
         text-shadow: none;
@@ -15,19 +12,13 @@
 }
 
 .navbar-bg-onscroll {
-
-    background:#3e3e3e!important;
-
-
+    background: #3e3e3e !important;
 
     opacity: inherit;
 }
 
 .td-navbar {
-
-    background:#3e3e3e;
-
-
+    background: #3e3e3e;
 
     min-height: 4rem;
     margin: 0;
@@ -64,16 +55,16 @@
         min-width: 100px;
     }
     @include media-breakpoint-down(md) {
-        padding-right: .5rem;
-        padding-left: .75rem;
+        padding-right: 0.5rem;
+        padding-left: 0.75rem;
         .td-navbar-nav-scroll {
             max-width: 100%;
             height: 2.5rem;
-            margin-top: .25rem;
+            margin-top: 0.25rem;
             overflow: hidden;
-            font-size: .875rem;
+            font-size: 0.875rem;
             .nav-link {
-                padding-right: .25rem;
+                padding-right: 0.25rem;
                 padding-left: 0;
             }
             .navbar-nav {
@@ -84,6 +75,11 @@
             }
         }
     }
+}
+
+// Make the announcement-bar invisible on all pages by default
+#announcement-bar {
+    display: none;
 }
 
 // Icons
@@ -108,9 +104,9 @@
             font-variant: normal;
             text-rendering: auto;
             -webkit-font-smoothing: antialiased;
-            font-family: "poppins";
+            font-family: 'poppins';
             font-weight: 900;
-            content: "\f0d9";
+            content: '\f0d9';
             padding-left: 0.5em;
             padding-right: 0.5em;
         }

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -4,13 +4,18 @@
         border-radius: .4rem;
     }
 </style>
-<!--If there is an announcement, uncomment the below line, add proper link and add 
-    style="margin-top: 35px;" into the <nav> element that exists directly below the <a> element
-    This way, it will force the navbar down and you will have room for your announcement.
+<!--
+    ! ANNOUNCEMENT HERE !
+    If there is an announcement:
+    - Uncomment the <a id="announcement-bar"...></a> on the line below
+        - The announcement will be visible only on the home page
+        - The announcement will also automatically format itself
+    - Update the announcement information
+        - Set the correct link
+        - Set the correct text
 -->
-<a href="https://www.youtube.com/watch?v=QfvuHrtacHs" target="_blank" class="fixed-top py-2 text-center text-bold text-white" style="background-color: #ffad00;">Check out our latest episode of Runtime Live from Oct 20, 2021</a>
+<a id="announcement-bar" href="https://www.youtube.com/watch?v=QfvuHrtacHs" target="_blank" class="fixed-top py-2 text-center text-bold text-white" style="background-color: #ffad00;">Check out our latest episode of Runtime Live from Oct 20, 2021</a>
 <nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
-
     <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
         <span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}</span>
     </a>


### PR DESCRIPTION
By default the announcement bar is now hidden on all pages.
To show it on a particular page use the following style tag:

```
<style>
	#announcement-bar {
		display: block;
	}
	#announcement-bar + .td-navbar {
    margin-top: 35px;
	}
</style>
```
