### PR TITLE
Add link-card and card-grid shortcodes

### DIFF
--- a/assets/scss/_shortcodes.scss
+++ b/assets/scss/_shortcodes.scss
@@ -1,0 +1,25 @@
+.link-card {
+    text-align: center;
+    padding: 1rem;
+    border: 1px solid #808080;
+    border-radius: 5px;
+
+    min-width: fit-content;
+    height: 100%;
+    h5 {
+        font-weight: bold;
+        min-width: fit-content;
+        white-space: nowrap;
+    }
+
+    p {
+        color: black;
+    }
+}
+
+.card-grid {
+    justify-content: center;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1em;
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -26,6 +26,7 @@
 @import "blocks/blocks";
 @import "section-index";
 @import "pageinfo";
+@import "shortcodes";
 
 @if $td-enable-google-fonts {
     @import url($web-font-path);

--- a/layouts/shortcodes/card-grid.html
+++ b/layouts/shortcodes/card-grid.html
@@ -1,0 +1,1 @@
+<div class="card-grid">{{ .Inner }}</div>

--- a/layouts/shortcodes/link-card.html
+++ b/layouts/shortcodes/link-card.html
@@ -1,0 +1,7 @@
+<a href="{{ .Get "href"  }}">
+  <div class="link-card">
+    <h5>{{ .Get "title" }}</h5>
+    <hr/>
+    <p>{{ .Get "desc" }}</p>
+  </div>
+</a>


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Created some shortcodes to create some "link-cards" and an auto formatting grid for the cards called "card-grid."
![image](https://user-images.githubusercontent.com/33691921/150447986-8897f7f9-33bf-49d2-8548-c0dd020be0fb.png)

**- How I did it**

- Local changes to at_docsy

**- How to verify it**

Review my code and see the screenshot above.

**- Description for the changelog**
Add link-card and card-grid shortcodes
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->